### PR TITLE
fix automount logger

### DIFF
--- a/stage3/02-sys-tweaks/files/media-automount
+++ b/stage3/02-sys-tweaks/files/media-automount
@@ -1,5 +1,6 @@
 #!/bin/bash
 #$1 = <dev>
+shopt -s expand_aliases
 
 # Default options to use for mounting
 AUTOMOUNT_OPTS='users'


### PR DESCRIPTION
bugfix: the `log` command would not be executed without (as the alias wouldn't be recognized)